### PR TITLE
Do not cache Conan config folder

### DIFF
--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -61,13 +61,13 @@ jobs:
 
       - name: Store Conan cache in zip
         shell: bash
-        run: conan cache save --no-source --file package-${{ steps.build-package.outputs.recipe-revision }}-${{ steps.build-package.outputs.package-id }}.tar.gz "*"
+        run: conan cache save --no-source --file package-${{ github.run_id }}.tar.gz "*"
 
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ steps.build-package.outputs.recipe-revision }}-${{ steps.build-package.outputs.package-id }}
-          path: package-${{ steps.build-package.outputs.recipe-revision }}-${{ steps.build-package.outputs.package-id }}.tar.gz
+          name: package-${{ github.run_id }}
+          path: package-${{ github.run_id }}.tar.gz
           overwrite: true
           retention-days: 1
           include-hidden-files: true

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-packages:
     name: build-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
     strategy:
       fail-fast: false
@@ -30,7 +30,7 @@ jobs:
         id: cache
         with:
             path: ${{ github.workspace }}/.conan2
-            key: conan-${{ runner.os }}
+            key: ${{ runner.os }}-conan
 
       - name: Consume Conan Action
         uses: ./
@@ -54,8 +54,39 @@ jobs:
         shell: bash
         run: conan list -c "*/*#latest:*"
 
-      - name: Cache Conan packages
+      - name: Upload Conan cache artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
+          path: ${{ github.workspace }}/.conan2/p
+
+  cache-packages:
+    runs-on: ubuntu-latest
+    needs: [build-packages]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.conan2
+          key: ${{ runner.os }}-conan
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "package-*"
+          path: ${{ github.workspace }}/.conan2/p
+          merge-multiple: true
+
+      - name: Consume Conan Action
+        uses: ./
+        with:
+          home: ${{ github.workspace }}/.conan2
+
+      - name: Verify merged artifacts
+        run: conan list -c "*/*#latest:*"
+
+      - name: Upload final Conan cache
         uses: actions/cache/save@v4
         with:
-            path: ${{ github.workspace }}/.conan2
-            key: conan-${{ runner.os }}
+          key: ${{ runner.os }}-conan
+          path: ${{ github.workspace }}/.conan2

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -109,13 +109,21 @@ jobs:
         with:
           home: ${{ github.workspace }}/.conan2
 
-      - name: Restore Conan saved artifacts
+      - name: Restore Conan saved artifacts (cross-platform)
         shell: bash
         run: |
-          shopt -s nullglob
-          for file in "${{ github.workspace }}"/package-*.tar.gz; do
-            conan cache restore "$file"
-          done
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            pwsh -Command '
+              $files = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\package-*.tar.gz"
+              foreach ($file in $files) {
+                conan cache restore "$($file.FullName)"
+              }
+            '
+          else
+            for file in "${{ github.workspace }}"/package-*.tar.gz; do
+              conan cache restore "$file"
+            done
+          fi
 
       - name: Verify merged artifacts
         shell: bash

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -41,12 +41,16 @@ jobs:
         shell: bash
         run: conan profile detect -e --name ${{ matrix.os }}
 
+      - name: List cached Conan packages before build
+        shell: bash
+        run: conan list -c "fmt/11.2.0#latest/*"
+
       - name: Build Conan packages
         shell: bash
         run: |
           conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=fmt/11.2.0 -o "*/*:shared=${{ matrix.shared }}" --build=missing
 
-      - name: List cached Conan packages
+      - name: List cached Conan packages after build
         shell: bash
         run: conan list -c "fmt/11.2.0#latest/*"
 

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -67,6 +67,7 @@ jobs:
           fi
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
           conan cache save --no-source --file package-${package_name}.tar.gz "*/*:*"
+          ls -la "${{ github.workspace }}"
 
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4
@@ -113,7 +114,7 @@ jobs:
       - name: Restore Conan saved artifacts
         shell: bash
         run: |
-          ls -la ${{ github.workspace }}/package-*
+          ls -la "${{ github.workspace }}"
           for file in ${{ github.workspace }}/package-*.tar.gz; do
             conan cache restore "$file"
           done

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -50,9 +50,7 @@ jobs:
         id: build-package
         run: |
           conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
-          conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}'
-          conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' | jq -r '.graph.nodes."1".package_id'
-          echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
+          echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
 
       - name: List cached Conan packages after build
         shell: bash

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -19,7 +19,7 @@ jobs:
             windows-2022,
           ]
         shared: ["True", "False"]
-        package: ["fmt/11.2.0", "nlohmann_json/3.12.0", "spdlog/1.15.3"]
+        package: ["fmt/11.2.0", "nlohmann_json/3.12.0", "spdlog/1.15.3", "gtest/1.16.0"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -45,7 +45,7 @@ jobs:
 
       - name: List cached Conan packages before build
         shell: bash
-        run: conan list -c "${{ matrix.package }}#latest:*"
+        run: conan list -c "*/*#latest:*"
 
       - name: Build Conan packages
         shell: bash
@@ -54,7 +54,7 @@ jobs:
 
       - name: List cached Conan packages after build
         shell: bash
-        run: conan list -c "${{ matrix.package }}#latest:*"
+        run: conan list -c "*/*#latest:*"
 
       - name: Cache Conan packages
         uses: actions/cache/save@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -50,7 +50,9 @@ jobs:
         id: build-package
         run: |
           conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
-          echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
+          conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}'
+          conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' | jq -r '.graph.nodes."1".package_id'
+          echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
 
       - name: List cached Conan packages after build
         shell: bash

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -88,7 +88,10 @@ jobs:
           home: ${{ github.workspace }}/.conan2
 
       - name: Verify merged artifacts
-        run: conan list -c "*/*#latest:*"
+        run: |
+          ls -la ${{ github.workspace }}/.conan2/p
+          ls -la ${{ github.workspace }}/.conan2/
+          conan list -c "*/*#latest:*"
 
       - name: Upload final Conan cache
         uses: actions/cache/save@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -58,19 +58,40 @@ jobs:
         shell: bash
         run: conan list -c "*/*#latest:*"
 
-      - name: Store Conan cache in zip
+      - name: Store Conan cache in zip on Unix
         shell: bash
-        id: save-cache
+        if: ${{ runner.os != 'Windows' }}
+        id: save-cache-unix
         run: |
           package_name=$(uuidgen)
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
           conan cache save --no-source --file package-${package_name}.tar.gz "*"
 
-      - name: Upload Conan cache artifacts
+      - name: Store Conan cache in zip on Windows
+        shell: pwsh
+        if: ${{ runner.os == 'Windows' }}
+        id: save-cache-windows
+        run: |
+          $package_name = [guid]::NewGuid().ToString()
+          Write-Output "package-name=$package_name" >> $env:GITHUB_OUTPUT
+          conan cache save --no-source --file "package-$package_name.tar.gz" "*"
+
+      - name: Upload Conan cache artifacts on Unix
+        if: ${{ runner.os != 'Windows' }}
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ steps.save-cache.outputs.package-name }}
-          path: package-${{ steps.save-cache.outputs.package-name }}.tar.gz
+          name: package-${{ steps.save-cache-unix.outputs.package-name }}
+          path: package-${{ steps.save-cache-unix.outputs.package-name }}.tar.gz
+          overwrite: true
+          retention-days: 1
+          include-hidden-files: true
+
+      - name: Upload Conan cache artifacts on Unix
+        if: ${{ runner.os == 'Windows' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-${{ steps.save-cache-windows.outputs.package-name }}
+          path: package-${{ steps.save-cache-windows.outputs.package-name }}.tar.gz
           overwrite: true
           retention-days: 1
           include-hidden-files: true

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -54,20 +54,19 @@ jobs:
           echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
           echo "recipe-revision=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".rrev')" >> $GITHUB_OUTPUT
 
-
       - name: List cached Conan packages after build
         shell: bash
         run: conan list -c "*/*#latest:*"
 
       - name: Store Conan cache in zip
         shell: bash
-        run: conan cache save --no-source --file package-${{ github.run_id }}.tar.gz "*"
+        run: conan cache save --no-source --file package-${{ github.run_id }}-${{ github.run_number }}.tar.gz "*"
 
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ github.run_id }}
-          path: package-${{ github.run_id }}.tar.gz
+          name: package-${{ github.run_id }}-${{ github.run_number }}
+          path: package-${{ github.run_id }}-${{ github.run_number }}.tar.gz
           overwrite: true
           retention-days: 1
           include-hidden-files: true

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          conan install -r conancenter --update ${{ github.workspace }}/test/conanfile.txt --build=missing
+          conan install -r conancenter --update --requires=fmt/11.2.0 --build=missing

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -38,12 +38,12 @@ jobs:
 
       - name: Configure Conan profile
         shell: bash
-        run: conan profile detect -e --name ${{ github.job }}
+        run: conan profile detect -e --name ${{ matrix.os }}
 
       - name: Build
         shell: bash
         run: |
-          conan install -pr:a ${{ github.job }} -r conancenter --update --requires=fmt/11.2.0 --build=missing
+          conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=fmt/11.2.0 --build=missing
 
       - name: Cache Conan packages
         uses: actions/cache/save@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: build-on-${{ matrix.os }}
+    name: build-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +19,8 @@ jobs:
             windows-2022,
           ]
         shared: ["True", "False"]
+        package: ["fmt/11.2.0", "nlohmann_json/3.12.0", "spdlog/1.15.3"]
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -43,16 +45,16 @@ jobs:
 
       - name: List cached Conan packages before build
         shell: bash
-        run: conan list -c "fmt/11.2.0#latest:*"
+        run: conan list -c "${{ matrix.package }}#latest:*"
 
       - name: Build Conan packages
         shell: bash
         run: |
-          conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=fmt/11.2.0 -o "*/*:shared=${{ matrix.shared }}" --build=missing
+          conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
 
       - name: List cached Conan packages after build
         shell: bash
-        run: conan list -c "fmt/11.2.0#latest:*"
+        run: conan list -c "${{ matrix.package }}#latest:*"
 
       - name: Cache Conan packages
         uses: actions/cache/save@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -30,8 +30,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.conan2/p
-          key: conan-cache-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
-          restore-keys: conan-cache-
+          key: conan-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
+          restore-keys: conan-cache-${{ runner.os }}-
 
       - name: Consume Conan Action
         uses: ./
@@ -88,7 +88,8 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.conan2
-          key: ${{ runner.os }}-conan
+          key: conan-cache-${{ runner.os }}-
+          restore-keys: conan-cache-${{ runner.os }}-
 
       - uses: actions/download-artifact@v4
         with:
@@ -117,5 +118,5 @@ jobs:
       - name: Upload final Conan cache
         uses: actions/cache/save@v4
         with:
-          key: conan-cache-${{ hashFiles('package-*.tar.gz') }}
+          key: conan-cache-${{ runner.os }}-${{ hashFiles('package-*.tar.gz') }}
           path: ${{ github.workspace }}/.conan2/p

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -82,6 +82,15 @@ jobs:
   cache-packages:
     runs-on: ubuntu-latest
     needs: [build-packages]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            macos-latest,
+            windows-latest,
+          ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -25,8 +25,18 @@ jobs:
 
       - name: Consume Conan Action
         uses: ./
+        with:
+          home: ${{ github.workspace }}/.conan2
 
       - name: Build
         shell: bash
         run: |
           conan install -r conancenter --update --requires=fmt/11.2.0 --build=missing
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+            path: ${{ github.workspace }}/.conan2
+            key: conan-${{ runner.os }}-${{ hashFiles('.conan2/**/*') }}
+            restore-keys: |
+              conan-${{ runner.os }}-

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -1,0 +1,32 @@
+name: Test Conan Action with external cache
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-22.04,
+            ubuntu-24.04,
+            macos-14,
+            macos-15,
+            windows-2022,
+          ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Consume Conan Action
+        uses: ./
+
+      - name: Build
+        shell: bash
+        run: |
+          conan install -r conancenter --update test/conanfile.txt --build=missing

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -30,9 +30,7 @@ jobs:
         id: cache
         with:
             path: ${{ github.workspace }}/.conan2
-            key: conan-${{ runner.os }}-${{ hashFiles('.conan2/**/*') }}
-            restore-keys: |
-              conan-${{ runner.os }}-
+            key: conan-${{ runner.os }}
 
       - name: Consume Conan Action
         uses: ./
@@ -60,4 +58,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
             path: ${{ github.workspace }}/.conan2
-            key: conan-${{ runner.os }}-${{ hashFiles('.conan2/**/*') }}
+            key: conan-${{ runner.os }}

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -18,6 +18,7 @@ jobs:
             macos-15,
             windows-2022,
           ]
+        shared: [True, False]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -40,10 +41,10 @@ jobs:
         shell: bash
         run: conan profile detect -e --name ${{ matrix.os }}
 
-      - name: Build
+      - name: Build Conan packages
         shell: bash
         run: |
-          conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=fmt/11.2.0 --build=missing
+          conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=fmt/11.2.0 -o "*/*:shared=${{ matrix.shared }}" --build=missing
 
       - name: Cache Conan packages
         uses: actions/cache/save@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -51,8 +51,6 @@ jobs:
         id: build-package
         run: |
           conan install -pr:a ${{ matrix.os }} --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
-          echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
-          echo "recipe-revision=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".rrev')" >> $GITHUB_OUTPUT
 
       - name: List cached Conan packages after build
         shell: bash

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -113,11 +113,12 @@ jobs:
         shell: bash
         run: |
           ls -la "${{ github.workspace }}"
-          for file in ${{ github.workspace }}/package-*.tar.gz; do
+          for file in "${{ github.workspace }}/package-*.tar.gz"; do
             conan cache restore "$file"
           done
 
       - name: Verify merged artifacts
+        shell: bash
         run: |
           ls -la ${{ github.workspace }}/.conan2/p
           ls -la ${{ github.workspace }}/.conan2/

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           name: package-${{ steps.build-package.outputs.package-id }}
           path: ${{ github.workspace }}/.conan2/p
+          overwrite: true
+          retention-days: 1
 
   cache-packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -26,12 +26,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/cache/restore@v4
-        id: cache
-        with:
-            path: ${{ github.workspace }}/.conan2
-            key: ${{ runner.os }}-conan
-
       - name: Consume Conan Action
         uses: ./
         with:

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -58,40 +58,23 @@ jobs:
         shell: bash
         run: conan list -c "*/*#latest:*"
 
-      - name: Store Conan cache in zip on Unix
+      - name: Store Conan cache
         shell: bash
-        if: ${{ runner.os != 'Windows' }}
-        id: save-cache-unix
+        id: save-cache
         run: |
-          package_name=$(uuidgen)
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            package_name=$(powershell -Command "[guid]::NewGuid().ToString()")
+          else
+            package_name=$(uuidgen)
+          fi
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
           conan cache save --no-source --file package-${package_name}.tar.gz "*"
 
-      - name: Store Conan cache in zip on Windows
-        shell: pwsh
-        if: ${{ runner.os == 'Windows' }}
-        id: save-cache-windows
-        run: |
-          $package_name = [guid]::NewGuid().ToString()
-          Write-Output "package-name=$package_name" >> $env:GITHUB_OUTPUT
-          conan cache save --no-source --file "package-$package_name.tar.gz" "*"
-
-      - name: Upload Conan cache artifacts on Unix
-        if: ${{ runner.os != 'Windows' }}
+      - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ steps.save-cache-unix.outputs.package-name }}
-          path: package-${{ steps.save-cache-unix.outputs.package-name }}.tar.gz
-          overwrite: true
-          retention-days: 1
-          include-hidden-files: true
-
-      - name: Upload Conan cache artifacts on Unix
-        if: ${{ runner.os == 'Windows' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: package-${{ steps.save-cache-windows.outputs.package-name }}
-          path: package-${{ steps.save-cache-windows.outputs.package-name }}.tar.gz
+          name: package-${{ steps.save-cache.outputs.package-name }}
+          path: package-${{ steps.save-cache.outputs.package-name }}.tar.gz
           overwrite: true
           retention-days: 1
           include-hidden-files: true

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -66,7 +66,6 @@ jobs:
           fi
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
           conan cache save --no-source --file package-${package_name}.tar.gz "*/*:*"
-          ls -la "${{ github.workspace }}"
 
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -47,8 +47,10 @@ jobs:
 
       - name: Build Conan packages
         shell: bash
+        id: build-package
         run: |
           conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
+          echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
 
       - name: List cached Conan packages after build
         shell: bash
@@ -57,7 +59,7 @@ jobs:
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
+          name: package-${{ steps.build-package.outputs.package-id }}
           path: ${{ github.workspace }}/.conan2/p
 
   cache-packages:

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -68,7 +68,7 @@ jobs:
             package_name=$(uuidgen)
           fi
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
-          conan cache save --no-source --file package-${package_name}.tar.gz "*"
+          conan cache save --no-source --file package-${package_name}.tar.gz "*/*:*"
 
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -18,7 +18,7 @@ jobs:
             macos-15,
             windows-2022,
           ]
-        shared: [True, False]
+        shared: ["True", "False"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: List cached Conan packages before build
         shell: bash
-        run: conan list -c "fmt/11.2.0#latest/*"
+        run: conan list -c "fmt/11.2.0#latest:*"
 
       - name: Build Conan packages
         shell: bash
@@ -52,7 +52,7 @@ jobs:
 
       - name: List cached Conan packages after build
         shell: bash
-        run: conan list -c "fmt/11.2.0#latest/*"
+        run: conan list -c "fmt/11.2.0#latest:*"
 
       - name: Cache Conan packages
         uses: actions/cache/save@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -88,8 +88,6 @@ jobs:
             macos-latest,
             windows-latest,
           ]
-        shared: ["True", "False"]
-        package: ["fmt/11.2.0", "nlohmann_json/3.12.0", "spdlog/1.15.3", "gtest/1.16.0"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -115,6 +113,7 @@ jobs:
       - name: Restore Conan saved artifacts
         shell: bash
         run: |
+          ls -la ${{ github.workspace }}/package-*
           for file in ${{ github.workspace }}/package-*.tar.gz; do
             conan cache restore "$file"
           done

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          conan install -r conancenter --update test/conanfile.txt --build=missing
+          conan install -r conancenter --update ${{ github.workspace }}/test/conanfile.txt --build=missing

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -60,13 +60,17 @@ jobs:
 
       - name: Store Conan cache in zip
         shell: bash
-        run: conan cache save --no-source --file package-${{ github.run_id }}-${{ github.run_number }}.tar.gz "*"
+        id: save-cache
+        run: |
+          package_name=$(uuidgen)
+          echo "package-name=${package_name}" >> $GITHUB_OUTPUT
+          conan cache save --no-source --file package-${package_name}.tar.gz "*"
 
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ github.run_id }}-${{ github.run_number }}
-          path: package-${{ github.run_id }}-${{ github.run_number }}.tar.gz
+          name: package-${{ steps.save-cache.outputs.package-name }}
+          path: package-${{ steps.save-cache.outputs.package-name }}.tar.gz
           overwrite: true
           retention-days: 1
           include-hidden-files: true

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -30,8 +30,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.conan2/p
-          key: conan-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
-          restore-keys: conan-cache-${{ runner.os }}-
+          key: conan-cache-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
+          restore-keys: conan-cache-
 
       - name: Consume Conan Action
         uses: ./
@@ -89,7 +89,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.conan2
           key: conan-cache-${{ runner.os }}-
-          restore-keys: conan-cache-${{ runner.os }}-
+          restore-keys: conan-cache-
 
       - uses: actions/download-artifact@v4
         with:
@@ -118,5 +118,5 @@ jobs:
       - name: Upload final Conan cache
         uses: actions/cache/save@v4
         with:
-          key: conan-cache-${{ runner.os }}-${{ hashFiles('package-*.tar.gz') }}
+          key: conan-cache-${{ hashFiles('package-*.tar.gz') }}
           path: ${{ github.workspace }}/.conan2/p

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -45,16 +45,22 @@ jobs:
         run: |
           conan install -pr:a ${{ matrix.os }} --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
           echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
+          echo "recipe-revision=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".rrev')" >> $GITHUB_OUTPUT
+
 
       - name: List cached Conan packages after build
         shell: bash
         run: conan list -c "*/*#latest:*"
 
+      - name: Store Conan cache in zip
+        shell: bash
+        run: conan cache save --no-source --file package-${{ steps.build-package.outputs.recipe-revision }}-${{ steps.build-package.outputs.package-id }}.tar.gz "*"
+
       - name: Upload Conan cache artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ steps.build-package.outputs.package-id }}
-          path: ${{ github.workspace }}/.conan2/p
+          name: package-${{ steps.build-package.outputs.recipe-revision }}-${{ steps.build-package.outputs.package-id }}
+          path: package-${{ steps.build-package.outputs.recipe-revision }}-${{ steps.build-package.outputs.package-id }}.tar.gz
           overwrite: true
           retention-days: 1
           include-hidden-files: true
@@ -80,6 +86,13 @@ jobs:
         uses: ./
         with:
           home: ${{ github.workspace }}/.conan2
+
+      - name: Restore Conan saved artifacts
+        shell: bash
+        run: |
+          for file in ${{ github.workspace }}/.conan2/p/package-*.tar.gz; do
+            conan cache restore --file "$file"
+          done
 
       - name: Verify merged artifacts
         run: |

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=fmt/11.2.0 -o "*/*:shared=${{ matrix.shared }}" --build=missing
 
+      - name: List cached Conan packages
+        shell: bash
+        run: conan list -c "fmt/11.2.0#latest/*"
+
       - name: Cache Conan packages
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: "package-*"
-          path: ${{ github.workspace }}/.conan2/p
+          path: ${{ github.workspace }}
           merge-multiple: true
 
       - name: Consume Conan Action

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -109,27 +109,17 @@ jobs:
         with:
           home: ${{ github.workspace }}/.conan2
 
-      - name: Restore Conan saved artifacts (cross-platform)
+      - name: Restore Conan saved artifacts
         shell: bash
         run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            pwsh -Command '
-              $files = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\package-*.tar.gz"
-              foreach ($file in $files) {
-                conan cache restore "$($file.FullName)"
-              }
-            '
-          else
-            for file in "${{ github.workspace }}"/package-*.tar.gz; do
-              conan cache restore "$file"
-            done
-          fi
+          shopt -s nullglob
+          for file in "${{ github.workspace }}"/package-*.tar.gz; do
+            conan cache restore "$file"
+          done
 
       - name: Verify merged artifacts
         shell: bash
         run: |
-          ls -la ${{ github.workspace }}/.conan2/p
-          ls -la ${{ github.workspace }}/.conan2/
           conan list -c "*/*#latest:*"
 
       - name: Upload final Conan cache

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -82,15 +82,6 @@ jobs:
   cache-packages:
     runs-on: ubuntu-latest
     needs: [build-packages]
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          [
-            ubuntu-latest,
-            macos-latest,
-            windows-latest,
-          ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         id: build-package
         run: |
-          conan install -pr:a ${{ matrix.os }} -r conancenter --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
+          conan install -pr:a ${{ matrix.os }} --update --requires=${{ matrix.package }} -o "*/*:shared=${{ matrix.shared }}" --build=missing
           echo "package-id=$(conan graph info -pr:a ${{ matrix.os }} --requires=${{ matrix.package }} -o '*/*:shared=${{ matrix.shared }}' --format=json | jq -r '.graph.nodes."1".package_id')" >> $GITHUB_OUTPUT
 
       - name: List cached Conan packages after build

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Restore Conan saved artifacts
         shell: bash
         run: |
-          ls -la "${{ github.workspace }}"
+          shopt -s nullglob
           for file in "${{ github.workspace }}"/package-*.tar.gz; do
             conan cache restore "$file"
           done

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -30,8 +30,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.conan2/p
-          key: conan-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
-          restore-keys: conan-cache-${{ runner.os }}
+          key: conan-cache-${{ runner.os }}
 
       - name: Consume Conan Action
         uses: ./
@@ -97,8 +96,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.conan2
-          key: conan-cache-${{ runner.os }}-
-          restore-keys: conan-cache-${{ runner.os }}-
+          key: conan-cache-${{ runner.os }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -128,5 +126,5 @@ jobs:
       - name: Upload final Conan cache
         uses: actions/cache/save@v4
         with:
-          key: conan-cache-${{ runner.os }}-${{ hashFiles('package-*.tar.gz') }}
+          key: conan-cache-${{ runner.os }}
           path: ${{ github.workspace }}/.conan2/p

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
         run: |
           for file in ${{ github.workspace }}/.conan2/p/package-*.tar.gz; do
-            conan cache restore --file "$file"
+            conan cache restore "$file"
           done
 
       - name: Verify merged artifacts

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -30,8 +30,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.conan2/p
-          key: conan-cache-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
-          restore-keys: conan-cache-
+          key: conan-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
+          restore-keys: conan-cache-${{ runner.os }}
 
       - name: Consume Conan Action
         uses: ./
@@ -78,8 +78,20 @@ jobs:
           include-hidden-files: true
 
   cache-packages:
-    runs-on: ubuntu-latest
     needs: [build-packages]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            macos-latest,
+            windows-latest,
+          ]
+        shared: ["True", "False"]
+        package: ["fmt/11.2.0", "nlohmann_json/3.12.0", "spdlog/1.15.3", "gtest/1.16.0"]
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -87,7 +99,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.conan2
           key: conan-cache-${{ runner.os }}-
-          restore-keys: conan-cache-
+          restore-keys: conan-cache-${{ runner.os }}-
 
       - uses: actions/download-artifact@v4
         with:
@@ -116,5 +128,5 @@ jobs:
       - name: Upload final Conan cache
         uses: actions/cache/save@v4
         with:
-          key: conan-cache-${{ hashFiles('package-*.tar.gz') }}
+          key: conan-cache-${{ runner.os }}-${{ hashFiles('package-*.tar.gz') }}
           path: ${{ github.workspace }}/.conan2/p

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore Conan cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.conan2/p
+          key: conan-cache-${{ matrix.os }}-${{ matrix.package }}-${{ matrix.shared }}
+          restore-keys: conan-cache-
+
       - name: Consume Conan Action
         uses: ./
         with:
@@ -90,7 +97,7 @@ jobs:
       - name: Restore Conan saved artifacts
         shell: bash
         run: |
-          for file in ${{ github.workspace }}/.conan2/p/package-*.tar.gz; do
+          for file in ${{ github.workspace }}/package-*.tar.gz; do
             conan cache restore "$file"
           done
 
@@ -103,5 +110,5 @@ jobs:
       - name: Upload final Conan cache
         uses: actions/cache/save@v4
         with:
-          key: ${{ runner.os }}-conan
-          path: ${{ github.workspace }}/.conan2
+          key: conan-cache-${{ hashFiles('package-*.tar.gz') }}
+          path: ${{ github.workspace }}/.conan2/p

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: build-on-${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,10 +36,14 @@ jobs:
         with:
           home: ${{ github.workspace }}/.conan2
 
+      - name: Configure Conan profile
+        shell: bash
+        run: conan profile detect -e --name ${{ github.job }}
+
       - name: Build
         shell: bash
         run: |
-          conan install -r conancenter --update --requires=fmt/11.2.0 --build=missing
+          conan install -pr:a ${{ github.job }} -r conancenter --update --requires=fmt/11.2.0 --build=missing
 
       - name: Cache Conan packages
         uses: actions/cache/save@v4

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -113,7 +113,7 @@ jobs:
         shell: bash
         run: |
           ls -la "${{ github.workspace }}"
-          for file in "${{ github.workspace }}/package-*.tar.gz"; do
+          for file in "${{ github.workspace }}"/package-*.tar.gz; do
             conan cache restore "$file"
           done
 

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -63,6 +63,7 @@ jobs:
           path: ${{ github.workspace }}/.conan2/p
           overwrite: true
           retention-days: 1
+          include-hidden-files: true
 
   cache-packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/cache/restore@v4
+        id: cache
+        with:
+            path: ${{ github.workspace }}/.conan2
+            key: conan-${{ runner.os }}-${{ hashFiles('.conan2/**/*') }}
+            restore-keys: |
+              conan-${{ runner.os }}-
+
       - name: Consume Conan Action
         uses: ./
         with:
@@ -34,9 +42,7 @@ jobs:
           conan install -r conancenter --update --requires=fmt/11.2.0 --build=missing
 
       - name: Cache Conan packages
-        uses: actions/cache@v4
+        uses: actions/cache/save@v4
         with:
             path: ${{ github.workspace }}/.conan2
             key: conan-${{ runner.os }}-${{ hashFiles('.conan2/**/*') }}
-            restore-keys: |
-              conan-${{ runner.os }}-

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ inputs:
     description: 'Cache all Conan packages from the cache'
     required: false
     default: 'false'
+    deprecationMessage: 'This input is deprecated and will be removed in future versions. Use actions/cache to cache Conan packages instead.'
   python_version:
     description: 'Python version to install'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -103,16 +103,6 @@ runs:
       run: |
         conan audit provider auth conancenter --token=${{ inputs.audit_token }}
 
-    - name: Cache Conan packages
-      if: ${{ inputs.cache_packages == 'true' }}
-      uses: actions/cache@v4.2.3
-      id: cache-conan-packages
-      with:
-        path: ${{ steps.get-conan-home.outputs.conan-home }}/p
-        key: conan-${{ steps.install-conan.outputs.conan-version }}-${{ runner.os }}
-        restore-keys: |
-          conan-${{ steps.install-conan.outputs.conan-version }}-${{ runner.os }}-
-
 branding:
   icon: 'package'
   color: 'blue'

--- a/test/conanfile.txt
+++ b/test/conanfile.txt
@@ -1,0 +1,2 @@
+[requires]
+fmt/11.2.0

--- a/test/conanfile.txt
+++ b/test/conanfile.txt
@@ -1,2 +1,0 @@
-[requires]
-fmt/11.2.0


### PR DESCRIPTION
### NOTES:

- Commit: [835ecb8](https://github.com/uilianries/setup-conan/pull/3/commits/835ecb83e58346dcf83bb460e0ec93f5ed73aaa4)

In this commit, we re-use the cache provided by the previous build, but the restore key matches for both builds on linux and mac. Result: The cached config is for GCC11 (ubuntu 22.04), then ubuntu 24.04 uses the same cache, including the wrong profile.
